### PR TITLE
Fix: drain stale LOGOUT responses during login

### DIFF
--- a/sdk/Client.go
+++ b/sdk/Client.go
@@ -68,6 +68,36 @@ func (c *Client) transmitCommandWithNoResponse(requestTc *TransmissionContainer)
 	return err
 }
 
+// receiveResponse reads and decodes a single response from the connection.
+func (c *Client) receiveResponse(timeout time.Duration) (*TransmissionContainer, error) {
+	receivedBytesTmp := make([]byte, 10240)
+	err := c.connection.SetReadDeadline(time.Now().Add(timeout))
+	if err != nil {
+		return nil, fmt.Errorf("failed to set read deadline. %v", err)
+	}
+	size, err := c.connection.Read(receivedBytesTmp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read network stream. %v", err)
+	}
+
+	c.log.Debugf("Length of received bytes: %d", size)
+	c.log.Debugf("Response bytes: %s", string(receivedBytesTmp[0:size]))
+
+	buffer := new(bytes.Buffer)
+	_, err = buffer.Write(receivedBytesTmp[0:size])
+	if err != nil {
+		return nil, fmt.Errorf("failed to write into buffer. %v", err)
+	}
+
+	receivedTc, err := DecodeTransmissionContainer(buffer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode transmission container. %v", err)
+	}
+
+	c.log.Debugf("Received TC: %v", receivedTc)
+	return receivedTc, nil
+}
+
 func (c *Client) transmitCommand(requestTc *TransmissionContainer, expectResponse bool) (*TransmissionContainer, error) {
 	c.log.Debugf("Request: %s", requestTc.String())
 	requestBytes, err := requestTc.Encode()
@@ -80,36 +110,11 @@ func (c *Client) transmitCommand(requestTc *TransmissionContainer, expectRespons
 		return nil, fmt.Errorf("failed to write into network stream. %v", err)
 	}
 
-	var receivedTc *TransmissionContainer
-
-	if expectResponse {
-		receivedBytesTmp := make([]byte, 10240)
-		err := c.connection.SetReadDeadline(time.Now().Add(time.Second * 5))
-		if err != nil {
-			return nil, fmt.Errorf("failed to set read deadline. %v", err)
-		}
-		size, err := c.connection.Read(receivedBytesTmp)
-		receivedHexString := string(receivedBytesTmp[0:size])
-		c.log.Debugf("Length of received bytes: %d", size)
-		c.log.Debugf("Response bytes: %s", receivedHexString)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read network stream. %v", err)
-		}
-
-		buffer := new(bytes.Buffer)
-		_, err = buffer.Write(receivedBytesTmp[0:size])
-		if err != nil {
-			return nil, fmt.Errorf("failed to write into buffer. %v", err)
-		}
-
-		receivedTc, err = DecodeTransmissionContainer(buffer)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode transmission container. %v", err)
-		}
-
-		c.log.Debugf("Received TC: %v", receivedTc)
+	if !expectResponse {
+		return nil, nil
 	}
-	return receivedTc, err
+
+	return c.receiveResponse(5 * time.Second)
 }
 
 func (c *Client) Open() error {
@@ -333,16 +338,29 @@ func (c *Client) Login(username string, password string) error {
 	tc := c.getTransmissionContainer(COMMANDID_LOGIN, payload.LoginPayload(username, password))
 	response, err := c.transmitCommandWithResponse(tc)
 	if err != nil {
-		return fmt.Errorf("failed to encode packet. %v", err)
+		return fmt.Errorf("failed to send login request. %v", err)
 	}
 
 	if response == nil {
 		return fmt.Errorf("unexpected nil response value")
 	}
 
+	// The gateway sends a LOGOUT frame for each stale session before the
+	// actual LOGIN response. Drain these before processing the login.
+	const maxDrain = 20
+	for i := 0; i < maxDrain; i++ {
+		if response.Packet.getCommandID() != COMMANDID_LOGOUT {
+			break
+		}
+		c.log.Debugf("Draining stale LOGOUT response (%d)", i+1)
+		response, err = c.receiveResponse(5 * time.Second)
+		if err != nil {
+			return fmt.Errorf("failed to read response while draining stale sessions. %v", err)
+		}
+	}
+
 	err = response.isResponseFor(tc)
 	if err != nil {
-		c.token = response.Packet.Token // TODO I don't like this logic but need to test something. Maybe this can be just simply deleted.
 		return fmt.Errorf("received unexpected packet (not the response waiting for). %s", response)
 	}
 


### PR DESCRIPTION
The gateway sends a LOGOUT frame for each stale session before the actual LOGIN response. Previously, Login() would fail with "received unexpected packet" if a stale LOGOUT arrived first (the existing TODO comment on line 345 of Client.go notes this issue).

This change drains up to 20 stale LOGOUT frames before processing the login response. Also extracts receiveResponse() as a reusable helper and simplifies transmitCommand() to use it.

Observed on a ProMatic 3 (firmware EE001425-14): stale sessions accumulate when connections are closed without sending LOGOUT (e.g. after crashes or network interruptions). The gateway then floods LOGOUTs on the next login attempt.

Thanks to @halacs for this project, which was essential for building my own garage door integration.