### PR TITLE
Fix hex encoding in payload String() methods

### DIFF
--- a/sdk/payload/GetPortsResponse.go
+++ b/sdk/payload/GetPortsResponse.go
@@ -16,7 +16,8 @@ func (gp *GetPortsResponse) Encode() []byte {
 
 func GetPortsResponsePayload(portIds []byte) PayloadInterface {
 	pl := Payload{
-		data: portIds,
+		data:       portIds,
+		dataLength: byte(len(portIds)), // #nosec G115 intentionally truncate data instead of safe cast
 	}
 
 	return &GetPortsResponse{
@@ -26,7 +27,7 @@ func GetPortsResponsePayload(portIds []byte) PayloadInterface {
 }
 
 func (gp *GetPortsResponse) String() string {
-	return fmt.Sprintf("GetPortsResponse: %s", gp.data)
+	return fmt.Sprintf("GetPortsResponse: %X", gp.data)
 }
 
 func (gp *GetPortsResponse) GetPortIds() []byte {

--- a/sdk/payload/GetType.go
+++ b/sdk/payload/GetType.go
@@ -27,7 +27,7 @@ func GetTypePayload(portId byte) PayloadInterface {
 }
 
 func (gt *GetType) String() string {
-	return fmt.Sprintf("GetType: %s", gt.data)
+	return fmt.Sprintf("GetType: %X", gt.data)
 }
 
 func DecodeGetTypePayload(payloadBytes []byte) (PayloadInterface, error) {

--- a/sdk/payload/GetTypeResponse.go
+++ b/sdk/payload/GetTypeResponse.go
@@ -29,7 +29,7 @@ func GetTypeResponsePayload(portId byte, portType byte) PayloadInterface {
 }
 
 func (gt *GetTypeResponse) String() string {
-	return fmt.Sprintf("GetTypeResponse: %s", gt.data)
+	return fmt.Sprintf("GetTypeResponse: %X", gt.data)
 }
 
 func (gt *GetTypeResponse) GetPortId() byte {


### PR DESCRIPTION
Good catch on the logging in #19, sorry about that! Fixed the String() methods in the payload types from #20 (GetPortsResponse, GetType, GetTypeResponse) to use `%X` instead of `%s` for byte data. Also set the missing `dataLength` in GetPortsResponsePayload for consistency.

Looks like the other payload String() methods have the same `%s` issue with byte data - happy to send a cleanup PR for those too if you'd like.