### PR TITLE
Log in on the connection before privileged port commands (add/inherit/remove)

### DIFF
--- a/cli/cmd/autologin.go
+++ b/cli/cmd/autologin.go
@@ -11,7 +11,7 @@ import (
 )
 
 func loginRequired(name string) bool {
-	loginRequiredCommands := []string{StatusCmdUse, SetStateCmdUse}
+	loginRequiredCommands := []string{StatusCmdUse, SetStateCmdUse, AddCmdUse, InheritCmdUse, RemoveCmdUse}
 
 	for _, i := range loginRequiredCommands {
 		if name == i {

--- a/cli/cmd/consts.go
+++ b/cli/cmd/consts.go
@@ -36,4 +36,7 @@ const (
 	ArgDoorStatusSupported         = "doorStatusSupported"
 	ArgDevicePortsName             = "devicePorts"
 	PortsCmdName                   = "ports"
+	AddCmdUse                      = "add"
+	InheritCmdUse                  = "inherit"
+	RemoveCmdUse                   = "remove"
 )

--- a/cli/cmd/portsAdd.go
+++ b/cli/cmd/portsAdd.go
@@ -12,7 +12,7 @@ import (
 )
 
 var portsAddCmd = &cobra.Command{
-	Use:   "add",
+	Use:   AddCmdUse,
 	Short: "Pair a new door by cloning a hand remote signal (ADD_PORT)",
 	Long: `Pair a new door by cloning a hand remote's radio signal.
 

--- a/cli/cmd/portsInherit.go
+++ b/cli/cmd/portsInherit.go
@@ -12,7 +12,7 @@ import (
 )
 
 var portsInheritCmd = &cobra.Command{
-	Use:   "inherit",
+	Use:   InheritCmdUse,
 	Short: "Pair a new door by transmitting the gateway's radio code (INHERIT_PORT)",
 	Long: `Pair a new door by having the gateway transmit its own radio code.
 

--- a/cli/cmd/portsRemove.go
+++ b/cli/cmd/portsRemove.go
@@ -15,9 +15,9 @@ func init() {
 	var devicePort int
 
 	portsRemoveCmd := &cobra.Command{
-		Use:   "remove",
-		Short: "Remove a paired port from the gateway",
-		Long:  `Remove a paired port (radio channel) from the gateway.`,
+		Use:     RemoveCmdUse,
+		Short:   "Remove a paired port from the gateway",
+		Long:    `Remove a paired port (radio channel) from the gateway.`,
 		PreRunE: preRunFuncs,
 		Run: func(cmd *cobra.Command, args []string) {
 			deviceMac := viper.GetString(ArgNameDeviceMac)


### PR DESCRIPTION
## Problem

`ports add`, `ports inherit`, and `ports remove` fire `ADD_PORT` / `INHERIT_PORT` / `REMOVE_PORT` on a fresh per-command connection (via `Generic`) carrying only a token. (These commands are also not in `loginRequired`, so nothing logs in for them either.)

On **my gateway (firmware `EE001425-15`)** those commands are rejected with `PERMISSION_DENIED` unless the `LOGIN` happened on the **same connection** as the privileged command. A valid token alone, which is fine for `SetState`/`GetStatus`, was not enough for these. The official app issues these on its single persistent post-login connection, which is presumably why it never hits this.

**Caveat:** this may be gateway/firmware specific. Your gateway may well accept the current token-only path for these commands (the `ports inherit`/`add` help text suggests it worked for you), so I don't want to claim this is universal. But logging in on the connection is harmless where it already worked and is what the app does, so it seemed like a safe fix either way. Happy to adjust if you'd rather gate it or handle it differently.

## Fix

Log in on the connection before the port-management command. The three CLI commands now take `username`/`password` (from config) instead of a token, and the wrappers do `Login` then the command on the one connection.

Notably nothing else was needed on my gateway. I first assumed a session-init handshake (`GET_USER_RIGHTS` / `GET_GROUPS` / `GET_GW_VERSION` / `GET_NAME`) was required, but comparing against the decompiled app (it sends the teach command with a null payload straight down the logged-in connection, no pre-handshake) and testing showed login-on-connection alone was enough here.

## Testing

Against my gateway, `ports add` with no remote pressed:

```
LOGIN (0x10)    -> Token 0x291A8A3B
ADD_PORT (0x29) with that token
Response: [ADD PORT ERROR]     (error 17, i.e. the command ran)
```

Previously this returned `PERMISSION_DENIED` (12). Getting `ADD_PORT_ERROR` rather than a port id also means no port was created.
